### PR TITLE
fix: use category prop from getStaticProps to prevent hydration mismatch on product pages

### DIFF
--- a/pages/products/[category]/[id]/index.js
+++ b/pages/products/[category]/[id]/index.js
@@ -42,11 +42,10 @@ export async function getStaticProps(context) {
   };
 }
 
-function ProductDetails({ staticProduct, searchInputText }) {
+function ProductDetails({ staticProduct, category, searchInputText }) {
   const product = staticProduct[0];
 
   const router = useRouter();
-  const { category } = router.query;
 
   const selectFirstColor = product?.colors[0];
   const [selectedArticle, setSelectedArticle] = useState(undefined);


### PR DESCRIPTION
Googlebot renders JavaScript and can catch product detail pages during
router hydration, when router.query is briefly empty ({}). This caused
canonical URLs and structured data to contain /products/undefined/114
instead of /products/elektro/114, potentially contributing to the
"Found - currently not indexed" status in Google Search Console.

The category is already passed as a prop from getStaticProps but was
never destructured in the component. Using it directly avoids any
dependency on router.query which is empty until the client-side router
initialises.

https://claude.ai/code/session_019JndMc72tEF5yvcVoFqvKd